### PR TITLE
The daemon for megaraid-status SAS should be megaraidsas-statusd

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,7 +57,7 @@ hwraid_device_database:
   # http://hwraid.le-vert.net/wiki/LSIMegaRAIDSAS
   - module:   'megaraid_sas'
     packages: [ 'megactl', 'megaraid-status' ]
-    daemons: [ 'megaclisas-statusd' ]
+    daemons: [ 'megaraidsas-statusd' ]
 
   # Adaptec AACRaid
   # http://hwraid.le-vert.net/wiki/Adaptec


### PR DESCRIPTION
Should fix #6. A new version doesn't need to be added yet. I'll also try to open a PR for #5 soon based on the discussion (maybe using the postfix module as an example).